### PR TITLE
Fix rowstart in forum links.

### DIFF
--- a/classes/postify/reply.php
+++ b/classes/postify/reply.php
@@ -107,7 +107,7 @@ class Postify_Reply extends Forum_Postify {
                 }
             }
 
-            $thread_last_page = ($thread_data['thread_postcount'] > self::$forum_settings['posts_per_page'] ? floor(floor($thread_data['thread_postcount'] / self::$forum_settings['posts_per_page']) * self::$forum_settings['posts_per_page']) : 0);
+            $thread_last_page = ($thread_data['thread_postcount'] > self::$forum_settings['posts_per_page'] ? floor(floor(($thread_data['thread_postcount'] - 1) / self::$forum_settings['posts_per_page']) * self::$forum_settings['posts_per_page']) : 0);
             $redirect_add = '';
             if ($thread_last_page) {
                 $redirect_add = '&amp;rowstart='.$thread_last_page;

--- a/classes/threads/threads.php
+++ b/classes/threads/threads.php
@@ -194,7 +194,7 @@ class ForumThreads extends ForumServer {
                     $thread_rowstart = '';
                     if (!empty($threads['thread_postcount']) && !empty($forum_settings['posts_per_page'])) {
                         if ($threads['thread_postcount'] > $forum_settings['posts_per_page']) {
-                            $thread_rowstart = $forum_settings['posts_per_page'] * floor($threads['thread_postcount'] / $forum_settings['posts_per_page']);
+                            $thread_rowstart = $forum_settings['posts_per_page'] * floor(($threads['thread_postcount'] - 1) / $forum_settings['posts_per_page']);
                             $thread_rowstart = "&amp;rowstart=".$thread_rowstart;
                         }
                     }


### PR DESCRIPTION
Fix rowstart in forum links.
With 39 posts it should go to page 2 with rowstart=20, not rowstart=40.