### PR TITLE
User Rank does not depend on the userlevel of the logged-in user (iMO…

### DIFF
--- a/classes/threads/threads.php
+++ b/classes/threads/threads.php
@@ -1124,7 +1124,7 @@ class ForumThreads extends ForumServer {
                     if ($forum_settings['forum_ranks']) {
                         $pdata['user_rank'] = iMOD ? self::show_forum_rank($pdata['user_posts'], 104, $pdata['user_groups']) : self::show_forum_rank($pdata['user_posts'], $pdata['user_level'], $pdata['user_groups']);
                     } else {
-                        $pdata['user_rank'] = iMOD ? $locale['userf1'] : getuserlevel($pdata['user_level']);
+                        $pdata['user_rank'] = getuserlevel($pdata['user_level']);
                     }
                 }
 


### PR DESCRIPTION
User Rank does not depend on the userlevel of the logged-in user (iMOD), but on the author of the post.
Without this patch, it will show 'Moderator' for every iMEMBER when viewed from an iMOD account.

In Forum 3.0 I don't see the rank listed when ranks are disabled in the settings.